### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -21,6 +21,12 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
 
 # In-memory activity database
 activities = {
+    "GitHub Skills": {
+        "description": "Hands-on GitHub collaboration and coding labs from the new partnership",
+        "schedule": "Mondays and Wednesdays, 5:00 PM - 6:00 PM",
+        "max_participants": 25,
+        "participants": []
+    },
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",


### PR DESCRIPTION
## Summary
- add the missing GitHub Skills activity to the in-memory catalog
- provide description, schedule, capacity, and empty participant list

## Testing
- manual: started app and verified GitHub Skills shows in activities list

Resolves #6.